### PR TITLE
Make CriticMarkup work with other bundles and other file types

### DIFF
--- a/Syntaxes/criticmarkup.tmLanguage
+++ b/Syntaxes/criticmarkup.tmLanguage
@@ -6,6 +6,8 @@
 	<array>
 		<string>critic</string>
 	</array>
+	<key>injectionSelector</key>
+	<string>L: text, source</string>
 	<key>keyEquivalent</key>
 	<string>^~C</string>
 	<key>name</key>
@@ -13,61 +15,48 @@
 	<key>patterns</key>
 	<array>
 		<dict>
-			<key>include</key>
-			<string>text.html.markdown</string>
+			<key>comment</key>
+			<string>Editorial Substitution</string>
+			<key>match</key>
+			<string>\{~~(.*?)~~\}</string>
+			<key>name</key>
+			<string>string.substitution</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Editorial Addition</string>
+			<key>match</key>
+			<string>\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}</string>
+			<key>name</key>
+			<string>string.addition</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Editorial Deletion</string>
+			<key>match</key>
+			<string>\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}</string>
+			<key>name</key>
+			<string>string.deletion</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Editorial Highlight</string>
+			<key>match</key>
+			<string>\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}</string>
+			<key>name</key>
+			<string>string.highlight</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Editorial Mark</string>
+			<key>match</key>
+			<string>\{&gt;&gt;(.*?)&lt;&lt;\}</string>
+			<key>name</key>
+			<string>string.comment</string>
 		</dict>
 	</array>
-	<key>injections</key>
-	<dict>
-		<key>text.html.markdown.critic</key>
-		<dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>comment</key>
-					<string>Editorial Substitution</string>
-					<key>match</key>
-					<string>\{~~(.*?)~~\}</string>
-					<key>name</key>
-					<string>string.substitution</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Editorial Addition</string>
-					<key>match</key>
-					<string>\{\+\+(.*?)\+\+[ \t]*(\[(.*?)\])?[ \t]*\}</string>
-					<key>name</key>
-					<string>string.addition</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Editorial Deletion</string>
-					<key>match</key>
-					<string>\{--(.*?)--[ \t]*(\[(.*?)\])?[ \t]*\}</string>
-					<key>name</key>
-					<string>string.deletion</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Editorial Highlight</string>
-					<key>match</key>
-					<string>\{\=\=(.*?)[ \t]*(\[(.*?)\])?[ \t]*\=\=\}</string>
-					<key>name</key>
-					<string>string.highlight</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>Editorial Mark</string>
-					<key>match</key>
-					<string>\{&gt;&gt;(.*?)&lt;&lt;\}</string>
-					<key>name</key>
-					<string>string.comment</string>
-				</dict>
-			</array>
-		</dict>
-	</dict>
 	<key>scopeName</key>
-	<string>text.html.markdown.critic</string>
+	<string>text.critic</string>
 	<key>uuid</key>
 	<string>2a1dd069-4748-4825-bf5f-0bb7d2db26dd</string>
 </dict>


### PR DESCRIPTION
Followed http://web.archiveorange.com/archive/v/DTyJuo68Dgm9lllwl14g and https://github.com/noniq/Merge-Markers.tmbundle to make CriticMarkup more general. Now it works in other bundles and other file types.

Note that I am using `L:text, source` instead of `L:source, text` because I think that CriticMarkup should match text first as it's where it'll most likely be used the most. Then match source code. Also note that `L:source, text` doesn't work well with https://github.com/streeter/markdown-redcarpet.tmbundle (the reverse order does).

Tested with https://gist.github.com/f7230384abe4d631c4e7 as shown below:
![screen shot 2014-11-18 at 1 25 07 am](https://cloud.githubusercontent.com/assets/2288213/5083315/c153b9ac-6ec1-11e4-8256-1378b00b0771.png)
